### PR TITLE
fix: improve RTL text detection for mixed emoji and Persian text

### DIFF
--- a/chrome/src/index.js
+++ b/chrome/src/index.js
@@ -102,9 +102,11 @@ function initObservers() {
       if (newNodes.length) {
         for (let node of newNodes) {
           const textContent = node.textContent;
+          const parentTextContent = node.parentNode?.textContent || '';
           const arabic = /[\u0600-\u06FF]/;
 
-          if (textContent && arabic.test(textContent)) {
+          if ((textContent && arabic.test(textContent)) || 
+              (parentTextContent && arabic.test(parentTextContent))) {
             node.parentNode.setAttribute("dir", "rtl");
           }
         }

--- a/chrome/src/index.js
+++ b/chrome/src/index.js
@@ -64,7 +64,10 @@ function applyRTLToBlocks() {
     ".notion-selectable.notion-bulleted_list-block"
   );
   bulletedListBlocks.forEach((block) => {
-    block.setAttribute("dir", "rtl");
+    const rtlTextFound = /[\u0600-\u06FF]/.test(block.textContent);
+    if (rtlTextFound) {
+      block.setAttribute("dir", "rtl");
+    }
   });
 
   const tableBlocks = document.querySelectorAll(".notion-table-block");

--- a/firefox/src/index.js
+++ b/firefox/src/index.js
@@ -102,9 +102,11 @@ function initObservers() {
       if (newNodes.length) {
         for (let node of newNodes) {
           const textContent = node.textContent;
+          const parentTextContent = node.parentNode?.textContent || '';
           const arabic = /[\u0600-\u06FF]/;
 
-          if (textContent && arabic.test(textContent)) {
+          if ((textContent && arabic.test(textContent)) || 
+              (parentTextContent && arabic.test(parentTextContent))) {
             node.parentNode.setAttribute("dir", "rtl");
           }
         }

--- a/firefox/src/index.js
+++ b/firefox/src/index.js
@@ -64,7 +64,10 @@ function applyRTLToBlocks() {
     ".notion-selectable.notion-bulleted_list-block"
   );
   bulletedListBlocks.forEach((block) => {
-    block.setAttribute("dir", "rtl");
+    const rtlTextFound = /[\u0600-\u06FF]/.test(block.textContent);
+    if (rtlTextFound) {
+      block.setAttribute("dir", "rtl");
+    }
   });
 
   const tableBlocks = document.querySelectorAll(".notion-table-block");


### PR DESCRIPTION
## Bug Fix: RTL Text Detection with Emojis

### What was fixed
- Fixed an issue where Persian text containing emojis wasn't being properly detected as RTL
- Improved text direction detection for mixed content (emoji + Persian text)

### Technical Details
- Added parent node text content check to ensure proper RTL detection
- Enhanced the text node analysis to handle split content
- Maintained backward compatibility with existing RTL detection

### Impact
This fix ensures that all Persian text blocks are properly displayed in RTL format, even when they contain emojis or other special characters at the beginning.

### How to test
1. Create a new Notion page
2. Add text with emojis followed by Persian text (e.g., "💡 نتیجه‌گیری نهایی:")
3. Verify that the text is properly aligned RTL